### PR TITLE
Customize selection color

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -41,6 +41,11 @@
     box-sizing: border-box;
 }
 
+::selection {
+  background-color: var(--accent);
+  color: var(--bg);
+}
+
 a, a:visited {
   color: var(--accent);
 }


### PR DESCRIPTION
Before:
<img width="223" height="156" alt="image" src="https://github.com/user-attachments/assets/265ea9f8-4ae8-471e-85a4-36202c86ae50" /> <img width="223" height="156" alt="image" src="https://github.com/user-attachments/assets/b84a5a5b-12f5-4f28-9a87-48b54a8ca34f" />


After:
<img width="223" height="156" alt="image" src="https://github.com/user-attachments/assets/ab11a911-ffec-4722-8397-3981504f53b8" /> <img width="223" height="156" alt="image" src="https://github.com/user-attachments/assets/aba20cc0-c36d-4648-adb0-d16de1dd158f" />

Unsure about the potential accessibility pitfalls of changing selection color. MDN says:
> Don't override selected text styles for purely aesthetic reasons — users can customize them to suit their needs [...]
> If overridden, it is important to ensure that the contrast ratio between the text and background colors of the selection is high enough that people experiencing low vision conditions can read it.

In this case, the contrast ratio of selection text / background colors is 7.38:1 on dark themes and 6.68:1 on light theme, which meets WCAG Level AA (and, for dark theme, WCAG Level AAA) according to https://webaim.org/resources/contrastchecker/

Inspiration: https://shellsharks.com/good-sitekeeping#highlight